### PR TITLE
feat: add route for flagging infected survivors

### DIFF
--- a/app/Exceptions/ExceptionCodes.php
+++ b/app/Exceptions/ExceptionCodes.php
@@ -5,4 +5,5 @@ namespace App\Exceptions;
 class ExceptionCodes
 {
     const RESOURCE_NOT_FOUND = 404;
+    const ORIGIN_FLAG_ALREADY_EXISTS = 419;
 }

--- a/app/Exceptions/OriginFlagAlreadyExistsException.php
+++ b/app/Exceptions/OriginFlagAlreadyExistsException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+use Throwable;
+
+class OriginFlagAlreadyExistsException extends Exception
+{
+    protected $message = "You have already flagged this survivor as infected";
+
+    public function __construct(Throwable $previous = null)
+    {
+        parent::__construct($this->message, $code = ExceptionCodes::ORIGIN_FLAG_ALREADY_EXISTS, $previous);
+    }
+}

--- a/app/Models/SurvivorFlagLog.php
+++ b/app/Models/SurvivorFlagLog.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SurvivorFlagLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'flag_origin',
+        'flagged_survivor'
+    ];
+}

--- a/app/Models/SurvivorInfectionFlag.php
+++ b/app/Models/SurvivorInfectionFlag.php
@@ -2,16 +2,22 @@
 
 namespace App\Models;
 
+use Grimzy\LaravelMysqlSpatial\Eloquent\SpatialTrait;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class SurvivorInfectionFlag extends Model
 {
     use HasFactory;
+    use SpatialTrait;
 
     protected $fillable = [
         'survivor_id',
         'count',
+        'last_location'
+    ];
+
+    protected $spatialFields = [
         'last_location'
     ];
 

--- a/app/Utils/Constants.php
+++ b/app/Utils/Constants.php
@@ -7,5 +7,6 @@ class Constants
 
     const PAGINATION_PER_PAGE = 20;
     const DEFAULT_DATE_SHORT_FORMAT = "M d, Y";
+    const FLAG_COUNT_THRESHOLD = 3;
 
 }

--- a/database/migrations/2021_11_11_225832_create_survivor_flag_logs_table.php
+++ b/database/migrations/2021_11_11_225832_create_survivor_flag_logs_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateSurvivorInfectionFlagsTable extends Migration
+class CreateSurvivorFlagLogsTable extends Migration
 {
     /**
      * Run the migrations.
@@ -13,11 +13,10 @@ class CreateSurvivorInfectionFlagsTable extends Migration
      */
     public function up()
     {
-        Schema::create('survivor_infection_flags', function (Blueprint $table) {
+        Schema::create('survivor_flag_logs', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('survivor_id')->constrained();
-            $table->integer('count')->default(1);
-            $table->point('last_location')->nullable();
+            $table->foreignId('flag_origin')->constrained('survivors');
+            $table->foreignId('flagged_survivor')->constrained('survivors');
             $table->timestamps();
         });
     }
@@ -29,6 +28,6 @@ class CreateSurvivorInfectionFlagsTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('survivor_infection_flags');
+        Schema::dropIfExists('survivor_flag_logs');
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,7 @@ Route::prefix('v1')->group(function () {
 
     Route::apiResource('survivors', SurvivorController::class);
     Route::put('survivors/{id}/last-location', [SurvivorController::class, 'updateLastLocation']);
+    Route::post('survivors/{id}/flag', [SurvivorController::class, 'flagInfectedSurvivor']);
 
     Route::apiResource('items', ItemController::class);
 


### PR DESCRIPTION
## Major activities carried out
- Custom exception for handling repeated flags from same origin
- Included route for flagging infected survivors
- Added migration and model for logging survivor flagging
- Logic to change survivor status from `CLEAN` to `INFECTED` once flag count reaches min 3